### PR TITLE
StatLight threw internal exceptions when trying to run test classes in the global namespace

### DIFF
--- a/src/StatLight.Client.Harness.MSTest/LogMessagTranslation/ReflectionInfoHelper.cs
+++ b/src/StatLight.Client.Harness.MSTest/LogMessagTranslation/ReflectionInfoHelper.cs
@@ -9,7 +9,7 @@ namespace StatLight.Client.Harness.Hosts.MSTest.LogMessagTranslation
         {
             var methodInfo = testMethod.Method;
             testExecutionMethod.NamespaceName = methodInfo.ReflectedType.Namespace;
-            testExecutionMethod.ClassName = methodInfo.ReflectedType.ReadClassName();
+            testExecutionMethod.ClassName = methodInfo.ReflectedType.ClassNameIncludingParentsIfNested();
             testExecutionMethod.MethodName = testMethod.Name;
         }
     }

--- a/src/StatLight.Client.Harness.MSTest/LogMessagTranslation/TestExecutionClassBeginClientEventMap.cs
+++ b/src/StatLight.Client.Harness.MSTest/LogMessagTranslation/TestExecutionClassBeginClientEventMap.cs
@@ -30,7 +30,7 @@ namespace StatLight.Client.Harness.Hosts.MSTest.LogMessagTranslation
             var testClass = (ITestClass)message.Decorators[UnitTestLogDecorator.TestClassMetadata];
             var clientEventX = new TestExecutionClassBeginClientEvent
                                    {
-                                       ClassName = testClass.Type.ReadClassName(),
+                                       ClassName = testClass.Type.ClassNameIncludingParentsIfNested(),
                                        NamespaceName = testClass.Type.Namespace,
                                    };
             return clientEventX;

--- a/src/StatLight.Client.Harness.MSTest/LogMessagTranslation/TestExecutionClassCompletedClientEventMap.cs
+++ b/src/StatLight.Client.Harness.MSTest/LogMessagTranslation/TestExecutionClassCompletedClientEventMap.cs
@@ -30,7 +30,7 @@ namespace StatLight.Client.Harness.Hosts.MSTest.LogMessagTranslation
             var testClass = (ITestClass)message.Decorators[UnitTestLogDecorator.TestClassMetadata];
             var clientEventX = new TestExecutionClassCompletedClientEvent
                                    {
-                                       ClassName = testClass.Type.ReadClassName(),
+                                       ClassName = testClass.Type.ClassNameIncludingParentsIfNested(),
                                        NamespaceName = testClass.Type.Namespace,
                                    };
             return clientEventX;

--- a/src/StatLight.Client.Harness.UnitDriven/UnitDrivenRunnerHost.cs
+++ b/src/StatLight.Client.Harness.UnitDriven/UnitDrivenRunnerHost.cs
@@ -148,7 +148,7 @@ namespace StatLight.Client.Harness.Hosts.UnitDriven
 
         private bool ShouldReportedThisInstanceOfTheFinalResult(MethodInfo methodInfo)
         {
-            var fullName = methodInfo.FullName();
+            var fullName = methodInfo.ReflectedType.FullName;
 
             // Using the property changed events to report messages 
             // puts in a place where we could potentially report multiple 
@@ -203,7 +203,7 @@ namespace StatLight.Client.Harness.Hosts.UnitDriven
         private static TestExecutionMethod PopulateCoreInfo(TestExecutionMethod testExecutionMethod, MethodInfo method)
         {
             testExecutionMethod.NamespaceName = method.ReflectedType.Namespace;
-            testExecutionMethod.ClassName = method.ReflectedType.ReadClassName();
+            testExecutionMethod.ClassName = method.ReflectedType.ClassNameIncludingParentsIfNested();
             testExecutionMethod.MethodName = method.Name;
             return testExecutionMethod;
         }

--- a/src/StatLight.Client.Harness/Hosts/ReflectionInfoHelper.cs
+++ b/src/StatLight.Client.Harness/Hosts/ReflectionInfoHelper.cs
@@ -7,20 +7,14 @@ namespace StatLight.Client.Harness.Hosts
 {
     public static class ReflectionInfoHelper
     {
-        public static string ReadClassName(this Type type)
+        /// <summary>
+        /// Namespace.Class+Nested+Nested2 -> Class+Nested+Nested2
+        /// </summary>
+        public static string ClassNameIncludingParentsIfNested(this Type type)
         {
-            return type.FullName.Substring(type.Namespace.Length + 1);
+            int nameStart = type.Namespace != null ? type.Namespace.Length+1 : 0;
+            return type.FullName.Substring(nameStart);
         }
-
-        public static string FullName(this MemberInfo methodInfo)
-        {
-            string m = "{0}.{1}.{2}".FormatWith(
-                        methodInfo.ReflectedType.Namespace,
-                        methodInfo.ReflectedType.ReadClassName(),
-                        methodInfo.Name);
-            return m;
-        }
-
 
         public static void HandleReflectionTypeLoadException(ReflectionTypeLoadException rfex)
         {

--- a/src/StatLight.Core/Configuration/ClientTestRunConfiguration.cs
+++ b/src/StatLight.Core/Configuration/ClientTestRunConfiguration.cs
@@ -107,7 +107,7 @@ namespace StatLight.Core.Configuration
             if (memberInfo == null)
                 throw new ArgumentNullException("memberInfo");
 
-            var methodName = memberInfo.FullName();
+            var methodName = memberInfo.ReflectedType.FullName;
             if (CurrentClientTestRunConfiguration.MethodsToTest.Count == 0)
                 return ShouldItBeRunInThisInstance(methodName);
 


### PR DESCRIPTION
When a class is in the global (sometimes called empty) namespace, Type::Namespace will return null. The patch proposes a way for correctly handling that, as well as getting rid of the confusing FullName extension method (this seriously confuses people because it contradicts System.Reflection Conventions)
